### PR TITLE
Add image date tag

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,1 @@
--P ubuntu-latest=nektos/act-environments-ubuntu:18.04
+-P ubuntu-latest=catthehacker/ubuntu:act-latest

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build the image.
         run: make

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -12,7 +12,7 @@ on:
         required: true
         default: "warning"
   schedule:
-    - cron: "0 0 1 */1 *"
+    - cron: "0 1 1 */1 *"
     # - cron: "*/5 * * * *" # 5 min testing
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build the image.
         run: make
@@ -52,21 +52,29 @@ jobs:
     needs: ci
     name: deploy
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip-deploy')"
 
     steps:
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Get current date
+        id: date
+        run: echo "DATE=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Build, tag and push the image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
-          tags: carlodepieri/docker-archlinux-ansible:latest
+          tags: |
+            carlodepieri/docker-archlinux-ansible:${{ steps.date.outputs.DATE }}
+            carlodepieri/docker-archlinux-ansible:latest
+          target: build

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # Docker Archlinux for testing Ansible playbooks
 
-[![prod](https://github.com/CarloDePieri/docker-archlinux-ansible/actions/workflows/prod.yml/badge.svg)](https://github.com/CarloDePieri/docker-archlinux-ansible/actions/workflows/prod.yml) [![Docker Cloud Automated build](https://img.shields.io/badge/docker%20build-automatic-success)](https://hub.docker.com/r/carlodepieri/docker-archlinux-ansible)
+[![prod](https://github.com/CarloDePieri/docker-archlinux-ansible/actions/workflows/prod.yml/badge.svg)](https://github.com/CarloDePieri/docker-archlinux-ansible/actions/workflows/prod.yml) [![Docker Cloud Automated build](https://img.shields.io/badge/docker%20build-automatic-success)](https://hub.docker.com/r/carlodepieri/docker-archlinux-ansible) [![Maintenance](https://img.shields.io/maintenance/yes/2025)](https://github.com/CarloDePieri/docker-archlinux-ansible)
 
 An updated, systemd-enabled Archlinux docker image (based on my [docker-archlinux-systemd](https://hub.docker.com/r/carlodepieri/docker-archlinux-systemd))
-useful for testing Ansible playbook. 
+useful for testing Ansible playbook.
 
-Images are built by GitHub CI and pushed to DockerHub at least once a month.
+Images are built by GitHub CI, tagged and pushed to DockerHub at least once a month.
+
+#### Available tags
+
+Arch is a rolling release distribution. This means that the [available tags](https://hub.docker.com/r/carlodepieri/docker-archlinux-ansible/tags)
+are nothing more than arbitrary snapshots of the distro at that particular time.
+
+Beware when using tags in automated testing environments: while usually a good
+practice, keep in mind that in reality Arch is changing daily and that a system
+test with a pinned environment could become useless quickly. A more in-depth
+discussion on this can be found [here](https://github.com/CarloDePieri/docker-archlinux-ansible/issues/6).
 
 ## Usage: testing with Molecule
 


### PR DESCRIPTION
Following discussion on #6 :

- every time the CI builds and push will also tag the image with the current date
- the readme now mention tags and there's a note about using pinned tags when testing

Also:
- this image will now be built an hour after its parent image, just to be safe it's using an up-to-date parent
- updates the actions to use up-to-date actions